### PR TITLE
Release/0.3.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,13 @@
+## 0.3.1 (November 10, 2022)
+
+FEATURES:
+* Upgrade to Terraform 1.3.4 and above.
+* Upgrade to AzureRm provider 3.31.0 and above.
+
+ENHANCEMENTS:
+* Delete the deprecated version constraint in the azurerm provider.
+* Code formatting with IntelliJ and `terraform fmt -recursive`.
+* Add a change log file.
+
+BUG FIXES:
+* Ensure that the option `private_ip_address_allocation` of the resource `azurerm_network_interface` is one of [Dynamic Static]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,3 +11,4 @@ ENHANCEMENTS:
 
 BUG FIXES:
 * Ensure that the option `private_ip_address_allocation` of the resource `azurerm_network_interface` is one of [Dynamic Static]
+* Replace the deprecated value `basic` by `Basic` of the parameter `Lb_sku` for the module `JamesDLD/Az-LoadBalancer/azurerm:0.2.1`

--- a/README.md
+++ b/README.md
@@ -4,13 +4,16 @@ Test
 
 Requirement
 -----
-- Terraform v1.1.3 and above. 
+
+- Terraform v1.1.3 and above.
 - AzureRm provider version v2.93 and above.
 
-Note : For VM Availability make sure to consider [SLA for Virtual Machines](https://azure.microsoft.com/en-us/support/legal/sla/virtual-machines/v1_9/?WT.mc_id=AZ-MVP-5003548)
+Note : For VM Availability make sure to
+consider [SLA for Virtual Machines](https://azure.microsoft.com/en-us/support/legal/sla/virtual-machines/v1_9/?WT.mc_id=AZ-MVP-5003548)
 
 Terraform resources used within the module
 -----
+
 | Resource | Description |
 |------|-------------|
 | [data azurerm_resource_group](https://www.terraform.io/docs/providers/azurerm/d/resource_group.html) | Get the Resource Group, re use it's tags for the sub resources. |
@@ -22,9 +25,9 @@ Terraform resources used within the module
 | [azurerm_network_interface_backend_address_pool_association](https://www.terraform.io/docs/providers/azurerm/r/network_interface_backend_address_pool_association.html) | Manages the association between a Network Interface and a Load Balancer's Backend Address Pool. |
 | [azurerm_virtual_machine](https://www.terraform.io/docs/providers/azurerm/r/virtual_machine.html) | Manages a Virtual Machine. |
 
-
 Examples
 -----
+
 | Name | Description |
 |------|-------------|
 | complete | Create the following objects : vnet, subnet, load balancer, linux and windows virtual machines. |

--- a/README.md
+++ b/README.md
@@ -5,8 +5,8 @@ Test
 Requirement
 -----
 
-- Terraform v1.1.3 and above.
-- AzureRm provider version v2.93 and above.
+- Terraform v1.3.4 and above.
+- AzureRm provider version v3.31 and above.
 
 Note : For VM Availability make sure to
 consider [SLA for Virtual Machines](https://azure.microsoft.com/en-us/support/legal/sla/virtual-machines/v1_9/?WT.mc_id=AZ-MVP-5003548)

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -21,7 +21,7 @@ variables:
   - name: vmImageName
     value: "ubuntu-latest"
   - name: terraform_version
-    value: "1.1.3"
+    value: "1.3.4"
   - name: artifact_name
     value: Az-Vm
   - name: backend_and_main_secret_file_id

--- a/examples/complete/README.md
+++ b/examples/complete/README.md
@@ -176,14 +176,14 @@ module "Create-AzureRmLoadBalancer-Demo" {
   lb_prefix              = "myproductvm-perimeter"
   lb_location            = data.azurerm_resource_group.rg.location
   lb_resource_group_name = data.azurerm_resource_group.rg.name
-  Lb_sku                 = "basic"
+  Lb_sku                 = "Basic"
   subnets                = { for x, y in azurerm_virtual_network.Demo.subnet : x.name => y }
   lb_additional_tags     = var.additional_tags
 }
 
 module "Az-Vm-Demo" {
   source                            = "JamesDLD/Az-Vm/azurerm"
-  version                           = "0.3.0"
+  version                           = "0.3.1"
   sa_bootdiag_storage_uri           = "https://infrasdbx1vpcjdld1.blob.core.windows.net/" #(Mandatory)
   subnets                           = { for x, y in azurerm_virtual_network.Demo.subnet : x.name => y }
   linux_vms                         = var.linux_vms   #(Mandatory)

--- a/examples/complete/README.md
+++ b/examples/complete/README.md
@@ -8,11 +8,13 @@ Create the following objects : vnet, subnet, load balancer, linux and windows vi
 
 Requirement
 -----
-- Terraform v1.1.3 and above. 
+
+- Terraform v1.1.3 and above.
 - AzureRm provider version v2.93 and above.
 
 Usage
 -----
+
 ```hcl
 #Set the terraform backend
 terraform {

--- a/examples/complete/README.md
+++ b/examples/complete/README.md
@@ -9,8 +9,8 @@ Create the following objects : vnet, subnet, load balancer, linux and windows vi
 Requirement
 -----
 
-- Terraform v1.1.3 and above.
-- AzureRm provider version v2.93 and above.
+- Terraform v1.3.4 and above.
+- AzureRm provider version v3.31 and above.
 
 Usage
 -----
@@ -170,7 +170,7 @@ resource "azurerm_virtual_network" "Demo" {
 
 module "Create-AzureRmLoadBalancer-Demo" {
   source                 = "JamesDLD/Az-LoadBalancer/azurerm"
-  version                = "0.2.0"
+  version                = "0.2.1"
   Lbs                    = var.Lbs
   LbRules                = var.LbRules
   lb_prefix              = "myproductvm-perimeter"

--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -169,7 +169,7 @@ resource "azurerm_virtual_network" "Demo" {
 #Call module
 module "Create-AzureRmLoadBalancer-Demo" {
   source                 = "JamesDLD/Az-LoadBalancer/azurerm"
-  version                = "0.2.0"
+  version                = "0.2.1"
   Lbs                    = var.Lbs
   LbRules                = var.LbRules
   lb_prefix              = "myproductvm-perimeter"
@@ -181,10 +181,11 @@ module "Create-AzureRmLoadBalancer-Demo" {
 }
 
 module "Az-Vm-Demo" {
-  source = "git::https://github.com/JamesDLD/terraform-azurerm-Az-Vm.git//?ref=master"
+  #source = "git::https://github.com/JamesDLD/terraform-azurerm-Az-Vm.git//?ref=master"
+  source = "git::https://github.com/JamesDLD/terraform-azurerm-Az-Vm.git//?ref=upgrade"
   #source = "../../"
   #source                  = "JamesDLD/Az-Vm/azurerm"
-  #version                 = "0.3.0"
+  #version                 = "0.3.1"
   sa_bootdiag_storage_uri = "https://infrasdbx1vpcjdld1.blob.core.windows.net/" #(Mandatory)
   subnets                 = { for x, y in azurerm_virtual_network.Demo.subnet : x.name => y }
   linux_vms               = var.linux_vms   #(Mandatory)

--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -175,7 +175,7 @@ module "Create-AzureRmLoadBalancer-Demo" {
   lb_prefix              = "myproductvm-perimeter"
   lb_location            = data.azurerm_resource_group.rg.location
   lb_resource_group_name = data.azurerm_resource_group.rg.name
-  Lb_sku                 = "basic"
+  Lb_sku                 = "Basic"
   subnets                = { for x, y in azurerm_virtual_network.Demo.subnet : x.name => y }
   lb_additional_tags     = var.additional_tags
 }

--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -181,8 +181,8 @@ module "Create-AzureRmLoadBalancer-Demo" {
 }
 
 module "Az-Vm-Demo" {
-  #source = "git::https://github.com/JamesDLD/terraform-azurerm-Az-Vm.git//?ref=master"
-  source = "git::https://github.com/JamesDLD/terraform-azurerm-Az-Vm.git//?ref=upgrade"
+  source = "git::https://github.com/JamesDLD/terraform-azurerm-Az-Vm.git//?ref=master"
+  #source = "git::https://github.com/JamesDLD/terraform-azurerm-Az-Vm.git//?ref=upgrade"
   #source = "../../"
   #source                  = "JamesDLD/Az-Vm/azurerm"
   #version                 = "0.3.1"

--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -50,7 +50,7 @@ variable "Lbs" {
 variable "LbRules" {
   default = {
     lbrules1 = {
-      Id                = "1"      #Id of a the rule within the Load Balancer 
+      Id                = "1"      #Id of a the rule within the Load Balancer
       lb_key            = "lb1"    #Id of the Load Balancer
       suffix_name       = "demovm" #It must equals the Lbs suffix_name
       lb_port           = "22"
@@ -66,13 +66,14 @@ variable "LbRules" {
 variable "linux_vms" {
   default = {
     vm1 = {
-      suffix_name          = "nva"             #(Mandatory) suffix of the vm
-      id                   = "1"               #(Mandatory) Id of the VM
-      storage_data_disks   = []                #(Mandatory) For no data disks set []
-      snet_key             = "demo2"           #Key of the Subnet
-      zones                = ["1"]             #Availability Zone id, could be 1, 2 or 3, if you don't need to set it to null or delete the line
-      vm_size              = "Standard_DS1_v2" #(Mandatory) 
-      managed_disk_type    = "Premium_LRS"     #(Mandatory) 
+      suffix_name        = "nva"   #(Mandatory) suffix of the vm
+      id                 = "1"     #(Mandatory) Id of the VM
+      storage_data_disks = []      #(Mandatory) For no data disks set []
+      snet_key           = "demo2" #Key of the Subnet
+      zones              = ["1"]
+      #Availability Zone id, could be 1, 2 or 3, if you don't need to set it to null or delete the line
+      vm_size              = "Standard_DS1_v2" #(Mandatory)
+      managed_disk_type    = "Premium_LRS"     #(Mandatory)
       enable_ip_forwarding = true              #(Optional)
     }
 
@@ -88,19 +89,25 @@ variable "linux_vms" {
           caching           = "ReadWrite"
           create_option     = "Empty"
         },
-      ]                                                        #(Mandatory) For no data disks set []
-      internal_lb_key               = "lb1"                    #(Optional) Key of the Internal Load Balancer, set to null or delete the line if there is no Load Balancer
-      public_lb_key                 = null                     #(Optional) Key of the public Load Balancer, set to null or delete the line if there is no public Load Balancer
-      public_ip_iteration           = null                     #(Optional) Id of the public Ip, set to null if there is no public Ip
-      snet_key                      = "demo1"                  #Key of the Subnet
-      zones                         = ["1"]                    #(Optional) Availability Zone id, could be 1, 2 or 3, if you don't need to set it to "", WARNING you could not have Availabilitysets and AvailabilityZones
-      nsg_key                       = null                     #(Optional) Key of the Network Security Group, set to null if there is no Network Security Groups
-      static_ip                     = "10.0.128.4"             #(Optional) Set null to get dynamic IP or delete this line
-      enable_accelerated_networking = false                    #(Optional) 
-      enable_ip_forwarding          = false                    #(Optional) 
-      vm_size                       = "Standard_DS1_v2"        #(Mandatory) 
-      managed_disk_type             = "Premium_LRS"            #(Mandatory) 
-      backup_policy_name            = "BackupPolicy-Schedule1" #(Optional) Set null to disable backup (WARNING, this will delete previous backup) otherwise set a backup policy like BackupPolicy-Schedule1
+      ] #(Mandatory) For no data disks set []
+      internal_lb_key = "lb1"
+      #(Optional) Key of the Internal Load Balancer, set to null or delete the line if there is no Load Balancer
+      public_lb_key = null
+      #(Optional) Key of the public Load Balancer, set to null or delete the line if there is no public Load Balancer
+      public_ip_iteration = null
+      #(Optional) Id of the public Ip, set to null if there is no public Ip
+      snet_key = "demo1" #Key of the Subnet
+      zones    = ["1"]
+      #(Optional) Availability Zone id, could be 1, 2 or 3, if you don't need to set it to "", WARNING you could not have Availabilitysets and AvailabilityZones
+      nsg_key = null
+      #(Optional) Key of the Network Security Group, set to null if there is no Network Security Groups
+      static_ip                     = "10.0.128.4"      #(Optional) Set null to get dynamic IP or delete this line
+      enable_accelerated_networking = false             #(Optional) 
+      enable_ip_forwarding          = false             #(Optional)
+      vm_size                       = "Standard_DS1_v2" #(Mandatory)
+      managed_disk_type             = "Premium_LRS"     #(Mandatory)
+      backup_policy_name            = "BackupPolicy-Schedule1"
+      #(Optional) Set null to disable backup (WARNING, this will delete previous backup) otherwise set a backup policy like BackupPolicy-Schedule1
     }
   }
 }
@@ -108,21 +115,24 @@ variable "linux_vms" {
 variable "windows_vms" {
   default = {
     vm1 = {
-      suffix_name                       = "rds"                             #(Mandatory) suffix of the vm
-      id                                = "1"                               #(Mandatory) Id of the VM
-      license_type                      = "Windows_Server"                  #(Optional) Specifies the BYOL Type for this Virtual Machine. This is only applicable to Windows Virtual Machines. Possible values are Windows_Client and Windows_Server.
-      admin_username                    = "myadmlogin"                      #(Optional) Use the one in the vm map if not provided
-      admin_password                    = "Myadmlogin_StoredInASecretFile?" #(Optional) Use the one in the vm map if not provided, #Warning : All arguments including the administrator login and password will be stored in the raw state as plain-text. Read more about sensitive data in state : https://www.terraform.io/docs/state/sensitive-data.html.
-      storage_image_reference_offer     = "WindowsServer"                   #(Optional)
-      storage_image_reference_publisher = "MicrosoftWindowsServer"          #(Optional)
-      storage_image_reference_sku       = "2019-Datacenter"                 #(Optional)
-      storage_image_reference_version   = "Latest"                          #(Optional)
-      storage_data_disks                = []                                #(Mandatory) For no data disks set []
-      enable_accelerated_networking     = true                              #(Optional) 
-      snet_key                          = "demo2"                           #Key of the Subnet
-      zones                             = ["1"]                             #Availability Zone id, could be 1, 2 or 3, if you don't need to set it to "", WARNING you could not have Availabilitysets and AvailabilityZones
-      vm_size                           = "Standard_F4s_v2"                 #"Standard_DS1_v2"        #(Mandatory) 
-      managed_disk_type                 = "Premium_LRS"                     #(Mandatory) 
+      suffix_name  = "rds" #(Mandatory) suffix of the vm
+      id           = "1"   #(Mandatory) Id of the VM
+      license_type = "Windows_Server"
+      #(Optional) Specifies the BYOL Type for this Virtual Machine. This is only applicable to Windows Virtual Machines. Possible values are Windows_Client and Windows_Server.
+      admin_username = "myadmlogin" #(Optional) Use the one in the vm map if not provided
+      admin_password = "Myadmlogin_StoredInASecretFile?"
+      #(Optional) Use the one in the vm map if not provided, #Warning : All arguments including the administrator login and password will be stored in the raw state as plain-text. Read more about sensitive data in state : https://www.terraform.io/docs/state/sensitive-data.html.
+      storage_image_reference_offer     = "WindowsServer"          #(Optional)
+      storage_image_reference_publisher = "MicrosoftWindowsServer" #(Optional)
+      storage_image_reference_sku       = "2019-Datacenter"        #(Optional)
+      storage_image_reference_version   = "Latest"                 #(Optional)
+      storage_data_disks                = []                       #(Mandatory) For no data disks set []
+      enable_accelerated_networking     = true                     #(Optional)
+      snet_key                          = "demo2"                  #Key of the Subnet
+      zones                             = ["1"]
+      #Availability Zone id, could be 1, 2 or 3, if you don't need to set it to "", WARNING you could not have Availabilitysets and AvailabilityZones
+      vm_size           = "Standard_F4s_v2" #"Standard_DS1_v2"        #(Mandatory)
+      managed_disk_type = "Premium_LRS"     #(Mandatory)
     }
   }
 }
@@ -175,14 +185,16 @@ module "Az-Vm-Demo" {
   #source = "../../"
   #source                  = "JamesDLD/Az-Vm/azurerm"
   #version                 = "0.3.0"
-  sa_bootdiag_storage_uri           = "https://infrasdbx1vpcjdld1.blob.core.windows.net/" #(Mandatory)
-  subnets                           = { for x, y in azurerm_virtual_network.Demo.subnet : x.name => y }
-  linux_vms                         = var.linux_vms   #(Mandatory)
-  windows_vms                       = var.windows_vms #(Mandatory)
-  vm_resource_group_name            = data.azurerm_resource_group.rg.name
-  vm_prefix                         = "myproductvm"                                                   #(Optional)
-  admin_username                    = "myadmlogin"                                                    #(Optional) Use the one in the vm map if not provided
-  admin_password                    = "Myadmlogin_StoredInASecretFile?"                               #(Optional) Use the one in the vm map if not provided, #Warning : When set you can delete this line this will delete the password from the tfstate. All arguments including the administrator login and password will be stored in the raw state as plain-text. Read more about sensitive data in state : https://www.terraform.io/docs/state/sensitive-data.html.
+  sa_bootdiag_storage_uri = "https://infrasdbx1vpcjdld1.blob.core.windows.net/" #(Mandatory)
+  subnets                 = { for x, y in azurerm_virtual_network.Demo.subnet : x.name => y }
+  linux_vms               = var.linux_vms   #(Mandatory)
+  windows_vms             = var.windows_vms #(Mandatory)
+  vm_resource_group_name  = data.azurerm_resource_group.rg.name
+  vm_prefix               = "myproductvm" #(Optional)
+  admin_username          = "myadmlogin"
+  #(Optional) Use the one in the vm map if not provided
+  admin_password = "Myadmlogin_StoredInASecretFile?"
+  #(Optional) Use the one in the vm map if not provided, #Warning : When set you can delete this line this will delete the password from the tfstate. All arguments including the administrator login and password will be stored in the raw state as plain-text. Read more about sensitive data in state : https://www.terraform.io/docs/state/sensitive-data.html.
   internal_lb_backend_address_pools = module.Create-AzureRmLoadBalancer-Demo.lb_backend_address_pools #(Optional)
   vm_additional_tags                = var.additional_tags                                             #(Optional)
 }

--- a/examples/linux-cloud-init/README.md
+++ b/examples/linux-cloud-init/README.md
@@ -4,20 +4,22 @@ Test
 
 Content
 -----
-Create a Linux VM with 3 Data Disks mounted through a [cloud init file](https://cloudinit.readthedocs.io/en/latest/topics/examples.html).
+Create a Linux VM with 3 Data Disks mounted through
+a [cloud init file](https://cloudinit.readthedocs.io/en/latest/topics/examples.html).
 
 | Description | Result |
 | ------------- | ------------- |
 | We are using the following [cloud init file : cloud-init-mount-three-disk.init](https://github.com/JamesDLD/terraform-azurerm-Az-Vm/blob/master/examples/linux-cloud-init/cloud-init-mount-three-disk.init)  | ![mounted_disk](https://raw.githubusercontent.com/JamesDLD/terraform-azurerm-Az-Vm/master/images/mounted_disk.png) |
 
-
 Requirement
 -----
-- Terraform v1.1.3 and above. 
+
+- Terraform v1.1.3 and above.
 - AzureRm provider version v2.93 and above.
 
 Usage
 -----
+
 ```hcl
 #Set the terraform backend
 terraform {

--- a/examples/linux-cloud-init/README.md
+++ b/examples/linux-cloud-init/README.md
@@ -14,8 +14,8 @@ a [cloud init file](https://cloudinit.readthedocs.io/en/latest/topics/examples.h
 Requirement
 -----
 
-- Terraform v1.1.3 and above.
-- AzureRm provider version v2.93 and above.
+- Terraform v1.3.4 and above.
+- AzureRm provider version v3.31 and above.
 
 Usage
 -----

--- a/examples/linux-cloud-init/main.tf
+++ b/examples/linux-cloud-init/main.tf
@@ -81,14 +81,16 @@ variable "linux_vms" {
           caching           = "ReadWrite"
           create_option     = "Empty"
         },
-      ]                                                  #(Mandatory) For no data disks set []     
-      linux_cloud_init_file_key     = "mount_three_disk" #(Optional)
-      snet_key                      = "demo1"            #Key of the Subnet
-      zones                         = ["1"]              #(Optional) Availability Zone id, could be 1, 2 or 3, if you don't need to set it to "", WARNING you could not have Availabilitysets and AvailabilityZones
-      nsg_key                       = null               #(Optional) Key of the Network Security Group, set to null if there is no Network Security Groups
-      enable_accelerated_networking = false              #(Optional) 
-      vm_size                       = "Standard_DS1_v2"  #(Mandatory) 
-      managed_disk_type             = "Premium_LRS"      #(Mandatory) 
+      ]                                              #(Mandatory) For no data disks set []     
+      linux_cloud_init_file_key = "mount_three_disk" #(Optional)
+      snet_key                  = "demo1"            #Key of the Subnet
+      zones                     = ["1"]
+      #(Optional) Availability Zone id, could be 1, 2 or 3, if you don't need to set it to "", WARNING you could not have Availabilitysets and AvailabilityZones
+      nsg_key = null
+      #(Optional) Key of the Network Security Group, set to null if there is no Network Security Groups
+      enable_accelerated_networking = false             #(Optional) 
+      vm_size                       = "Standard_DS1_v2" #(Mandatory)
+      managed_disk_type             = "Premium_LRS"     #(Mandatory)
     }
   }
 }
@@ -151,8 +153,9 @@ module "Az-Vm-Demo" {
   linux_cloud_init_contents = data.template_cloudinit_config.config #(Optional)
   windows_vms               = {}                                    #(Mandatory)
   vm_resource_group_name    = data.azurerm_resource_group.rg.name
-  vm_prefix                 = "myproductvm"                     #(Optional)
-  admin_username            = "myadmlogin"                      #(Optional) Use the one in the vm map if not provided
-  admin_password            = "Myadmlogin_StoredInASecretFile?" #(Optional) Use the one in the vm map if not provided, #Warning : When set you can delete this line this will delete the password from the tfstate. All arguments including the administrator login and password will be stored in the raw state as plain-text. Read more about sensitive data in state : https://www.terraform.io/docs/state/sensitive-data.html.
-  vm_additional_tags        = var.additional_tags               #(Optional)
+  vm_prefix                 = "myproductvm" #(Optional)
+  admin_username            = "myadmlogin"  #(Optional) Use the one in the vm map if not provided
+  admin_password            = "Myadmlogin_StoredInASecretFile?"
+  #(Optional) Use the one in the vm map if not provided, #Warning : When set you can delete this line this will delete the password from the tfstate. All arguments including the administrator login and password will be stored in the raw state as plain-text. Read more about sensitive data in state : https://www.terraform.io/docs/state/sensitive-data.html.
+  vm_additional_tags = var.additional_tags #(Optional)
 }

--- a/files/InitializeVM.ps1
+++ b/files/InitializeVM.ps1
@@ -3,13 +3,14 @@ Start-Transcript -Path "C:\terraform\$date-InitializeVM.log"
 
 #region WinRm https
 $profiles = Get-NetConnectionProfile
-Foreach ($i in $profiles) {
+Foreach ($i in $profiles)
+{
     Write-Host ("Updating Interface ID {0} to be Private.." -f $profiles.InterfaceIndex)
     Set-NetConnectionProfile -InterfaceIndex $profiles.InterfaceIndex -NetworkCategory Private
 }
 
 Write-Host "Obtaining the Thumbprint of the Certificate from KeyVault"
-$Thumbprint = (Get-ChildItem -Path Cert:\LocalMachine\My | Where-Object {$_.Subject -match "$ComputerName"}).Thumbprint
+$Thumbprint = (Get-ChildItem -Path Cert:\LocalMachine\My | Where-Object { $_.Subject -match "$ComputerName" }).Thumbprint
 
 Write-Host "Enable HTTPS in WinRM.."
 winrm create winrm/config/Listener?Address=*+Transport=HTTPS "@{Hostname=`"$ComputerName`"; CertificateThumbprint=`"$Thumbprint`"}"
@@ -22,13 +23,14 @@ net stop winrm
 net start winrm
 
 Write-Host "Open Firewall Ports"
-netsh advfirewall firewall add rule name="Windows Remote Management (HTTPS-In)" dir=in action=allow protocol=TCP localport=5986
+netsh advfirewall firewall add rule name = "Windows Remote Management (HTTPS-In)" dir = in action = allow protocol = TCP localport = 5986
 #endregion
 
 #region Initialize DataDisk
 Write-Host "Initialize Disks"
 $drv = Get-WmiObject win32_volume -filter 'DriveType = "5"'
-if ($drv) {
+if ($drv)
+{
     $drv.DriveLetter = "Z:"
     $drv.Put() | out-null
 }
@@ -38,13 +40,14 @@ $letters = 69..85 | ForEach-Object { [char]$_ }
 $count = 0
 $labels = "data1", "data2", "data3", "data4", "data5"
 
-foreach ($disk in $disks) {
+foreach ($disk in $disks)
+{
     $driveLetter = $letters[$count].ToString()
     Write-Host "Initialize Disk : $driveLetter"
-    $disk | 
-        Initialize-Disk -PartitionStyle MBR -PassThru |
-        New-Partition -UseMaximumSize -DriveLetter $driveLetter |
-        Format-Volume -FileSystem NTFS -NewFileSystemLabel $labels[$count] -Confirm:$false -Force
+    $disk |
+            Initialize-Disk -PartitionStyle MBR -PassThru |
+            New-Partition -UseMaximumSize -DriveLetter $driveLetter |
+            Format-Volume -FileSystem NTFS -NewFileSystemLabel $labels[$count] -Confirm:$false -Force
     Write-Host "End of task : Initialize Disk : $driveLetter"
     $count++
 }

--- a/main.tf
+++ b/main.tf
@@ -124,7 +124,8 @@ resource "azurerm_network_interface" "linux_nics" {
 # - Linux Network interfaces - Network Security Groups
 # -
 resource "azurerm_network_interface_security_group_association" "linux_nics_with_nsg" {
-  depends_on                = [azurerm_network_interface.linux_nics, azurerm_virtual_machine.linux_vms] #did add the depedency because of the following issue : https://github.com/terraform-providers/terraform-provider-azurerm/issues/4330
+  depends_on = [azurerm_network_interface.linux_nics, azurerm_virtual_machine.linux_vms]
+  #did add the depedency because of the following issue : https://github.com/terraform-providers/terraform-provider-azurerm/issues/4330
   for_each                  = { for x, y in var.linux_vms : x => y if lookup(y, "nsg_key", null) == null ? false : true }
   network_interface_id      = azurerm_network_interface.linux_nics[each.key].id
   network_security_group_id = lookup(var.network_security_groups, each.value["nsg_key"], null)["id"]
@@ -134,7 +135,8 @@ resource "azurerm_network_interface_security_group_association" "linux_nics_with
 # - Linux Network interfaces - Internal backend pools
 # -
 resource "azurerm_network_interface_backend_address_pool_association" "linux_nics_with_internal_backend_pools" {
-  depends_on              = [azurerm_network_interface.linux_nics, azurerm_virtual_machine.linux_vms] #did add the depedency because of the following issue : https://github.com/terraform-providers/terraform-provider-azurerm/issues/4330
+  depends_on = [azurerm_network_interface.linux_nics, azurerm_virtual_machine.linux_vms]
+  #did add the depedency because of the following issue : https://github.com/terraform-providers/terraform-provider-azurerm/issues/4330
   for_each                = { for x, y in var.linux_vms : x => y if lookup(y, "internal_lb_key", null) == null ? false : true }
   network_interface_id    = azurerm_network_interface.linux_nics[each.key].id
   ip_configuration_name   = "${var.vm_prefix}${each.value["suffix_name"]}${each.value["id"]}nic001-CFG"
@@ -145,7 +147,8 @@ resource "azurerm_network_interface_backend_address_pool_association" "linux_nic
 # - Linux Network interfaces - Public backend pools
 # -
 resource "azurerm_network_interface_backend_address_pool_association" "linux_nics_with_public_backend_pools" {
-  depends_on              = [azurerm_network_interface.linux_nics, azurerm_virtual_machine.linux_vms] #did add the depedency because of the following issue : https://github.com/terraform-providers/terraform-provider-azurerm/issues/4330
+  depends_on = [azurerm_network_interface.linux_nics, azurerm_virtual_machine.linux_vms]
+  #did add the depedency because of the following issue : https://github.com/terraform-providers/terraform-provider-azurerm/issues/4330
   for_each                = { for x, y in var.linux_vms : x => y if lookup(y, "public_lb_key", null) == null ? false : true }
   network_interface_id    = azurerm_network_interface.linux_nics[each.key].id
   ip_configuration_name   = "${var.vm_prefix}${each.value["suffix_name"]}${each.value["id"]}nic001-CFG"
@@ -213,7 +216,8 @@ resource "azurerm_virtual_machine" "linux_vms" {
     computer_name  = "${var.vm_prefix}${each.value["suffix_name"]}${each.value["id"]}"
     admin_username = lookup(each.value, "admin_username", var.admin_username)
     admin_password = lookup(each.value, "admin_password", var.admin_password)
-    custom_data    = lookup(each.value, "linux_cloud_init_file_key", null) == null ? null : var.linux_cloud_init_contents[each.value.linux_cloud_init_file_key].rendered #(Optional) Specifies custom data to supply to the machine. On Linux-based systems, this can be used as a cloud-init script. On other systems, this will be copied as a file on disk. Internally, Terraform will base64 encode this value before sending it to the API. The maximum length of the binary array is 65535 bytes.
+    custom_data    = lookup(each.value, "linux_cloud_init_file_key", null) == null ? null : var.linux_cloud_init_contents[each.value.linux_cloud_init_file_key].rendered
+    #(Optional) Specifies custom data to supply to the machine. On Linux-based systems, this can be used as a cloud-init script. On other systems, this will be copied as a file on disk. Internally, Terraform will base64 encode this value before sending it to the API. The maximum length of the binary array is 65535 bytes.
   }
 
   dynamic "identity" {
@@ -323,7 +327,8 @@ resource "azurerm_network_interface" "windows_nics" {
 # - Windows Network interfaces - Network Security Groups
 # -
 resource "azurerm_network_interface_security_group_association" "windows_nics_with_nsg" {
-  depends_on                = [azurerm_network_interface.linux_nics, azurerm_virtual_machine.linux_vms] #did add the depedency because of the following issue : https://github.com/terraform-providers/terraform-provider-azurerm/issues/4330
+  depends_on = [azurerm_network_interface.linux_nics, azurerm_virtual_machine.linux_vms]
+  #did add the depedency because of the following issue : https://github.com/terraform-providers/terraform-provider-azurerm/issues/4330
   for_each                  = { for x, y in var.windows_vms : x => y if lookup(y, "nsg_key", null) == null ? false : true }
   network_interface_id      = azurerm_network_interface.windows_nics[each.key].id
   network_security_group_id = lookup(var.network_security_groups, each.value["nsg_key"], null)["id"]
@@ -333,7 +338,8 @@ resource "azurerm_network_interface_security_group_association" "windows_nics_wi
 # - Windows Network interfaces - Internal backend pools
 # -
 resource "azurerm_network_interface_backend_address_pool_association" "windows_nics_with_internal_backend_pools" {
-  depends_on              = [azurerm_network_interface.windows_nics, azurerm_virtual_machine.windows_vms] #did add the depedency because of the following issue : https://github.com/terraform-providers/terraform-provider-azurerm/issues/4330
+  depends_on = [azurerm_network_interface.windows_nics, azurerm_virtual_machine.windows_vms]
+  #did add the depedency because of the following issue : https://github.com/terraform-providers/terraform-provider-azurerm/issues/4330
   for_each                = { for x, y in var.windows_vms : x => y if lookup(y, "internal_lb_key", null) == null ? false : true }
   network_interface_id    = azurerm_network_interface.windows_nics[each.key].id
   ip_configuration_name   = "${var.vm_prefix}${each.key}nic001-CFG"
@@ -344,7 +350,8 @@ resource "azurerm_network_interface_backend_address_pool_association" "windows_n
 # - Windows Network interfaces - Public backend pools
 # -
 resource "azurerm_network_interface_backend_address_pool_association" "windows_nics_with_public_backend_pools" {
-  depends_on              = [azurerm_network_interface.windows_nics, azurerm_virtual_machine.windows_vms] #did add the depedency because of the following issue : https://github.com/terraform-providers/terraform-provider-azurerm/issues/4330
+  depends_on = [azurerm_network_interface.windows_nics, azurerm_virtual_machine.windows_vms]
+  #did add the depedency because of the following issue : https://github.com/terraform-providers/terraform-provider-azurerm/issues/4330
   for_each                = { for x, y in var.windows_vms : x => y if lookup(y, "public_lb_key", null) == null ? false : true }
   network_interface_id    = azurerm_network_interface.windows_nics[each.key].id
   ip_configuration_name   = "${var.vm_prefix}${each.key}nic001-CFG"
@@ -355,14 +362,15 @@ resource "azurerm_network_interface_backend_address_pool_association" "windows_n
 # - Windows Virtual Machines
 # -
 resource "azurerm_virtual_machine" "windows_vms" {
-  for_each                         = var.windows_vms
-  name                             = "${var.vm_prefix}${each.value["suffix_name"]}${each.value["id"]}"
-  location                         = local.location
-  resource_group_name              = var.vm_resource_group_name
-  network_interface_ids            = [lookup(azurerm_network_interface.windows_nics, each.key)["id"]]
-  zones                            = lookup(each.value, "zones", null)
-  vm_size                          = each.value["vm_size"]
-  license_type                     = lookup(each.value, "license_type", null) # (Optional) Specifies the BYOL Type for this Virtual Machine. This is only applicable to Windows Virtual Machines. Possible values are Windows_Client and Windows_Server.
+  for_each              = var.windows_vms
+  name                  = "${var.vm_prefix}${each.value["suffix_name"]}${each.value["id"]}"
+  location              = local.location
+  resource_group_name   = var.vm_resource_group_name
+  network_interface_ids = [lookup(azurerm_network_interface.windows_nics, each.key)["id"]]
+  zones                 = lookup(each.value, "zones", null)
+  vm_size               = each.value["vm_size"]
+  license_type          = lookup(each.value, "license_type", null)
+  # (Optional) Specifies the BYOL Type for this Virtual Machine. This is only applicable to Windows Virtual Machines. Possible values are Windows_Client and Windows_Server.
   delete_os_disk_on_termination    = lookup(each.value, "delete_os_disk_on_termination", true)
   delete_data_disks_on_termination = lookup(each.value, "delete_data_disks_on_termination", true)
   boot_diagnostics {

--- a/main.tf
+++ b/main.tf
@@ -112,7 +112,7 @@ resource "azurerm_network_interface" "linux_nics" {
   ip_configuration {
     name                          = "${var.vm_prefix}${each.value["suffix_name"]}${each.value["id"]}nic001-CFG"
     subnet_id                     = lookup(var.subnets, each.value["snet_key"], null)["id"]
-    private_ip_address_allocation = lookup(each.value, "static_ip", null) == null ? "dynamic" : "static"
+    private_ip_address_allocation = lookup(each.value, "static_ip", null) == null ? "Dynamic" : "Static"
     private_ip_address            = lookup(each.value, "static_ip", null)
     public_ip_address_id          = lookup(each.value, "public_ip_key", null) == null ? null : lookup(var.public_ips, each.value["public_ip_key"], null)["id"]
   }
@@ -315,7 +315,7 @@ resource "azurerm_network_interface" "windows_nics" {
   ip_configuration {
     name                          = "${var.vm_prefix}${each.value["suffix_name"]}${each.value["id"]}nic001-CFG"
     subnet_id                     = lookup(var.subnets, each.value["snet_key"], null)["id"]
-    private_ip_address_allocation = lookup(each.value, "static_ip", null) == null ? "dynamic" : "static"
+    private_ip_address_allocation = lookup(each.value, "static_ip", null) == null ? "Dynamic" : "Static"
     private_ip_address            = lookup(each.value, "static_ip", null)
     public_ip_address_id          = lookup(each.value, "public_ip_key", null) == null ? null : lookup(var.public_ips, each.value["public_ip_key"], null)["id"]
   }

--- a/var.tf
+++ b/var.tf
@@ -1,5 +1,3 @@
-
-
 variable "sa_bootdiag_storage_uri" {
   type        = string
   description = "Azure Storage Account Primary Queue Service Endpoint."

--- a/versions.tf
+++ b/versions.tf
@@ -1,3 +1,3 @@
 terraform {
-  required_version = ">= 0.12.6"
+  required_version = ">= 1.3.4"
 }


### PR DESCRIPTION
## 0.3.1 (November 10, 2022)

FEATURES:
* Upgrade to Terraform 1.3.4 and above.
* Upgrade to AzureRm provider 3.31.0 and above.

ENHANCEMENTS:
* Delete the deprecated version constraint in the azurerm provider.
* Code formatting with IntelliJ and `terraform fmt -recursive`.
* Add a change log file.

BUG FIXES:
* Ensure that the option `private_ip_address_allocation` of the resource `azurerm_network_interface` is one of [Dynamic Static]
* Replace the deprecated value `basic` by `Basic` of the parameter `Lb_sku` for the module `JamesDLD/Az-LoadBalancer/azurerm:0.2.1`